### PR TITLE
Add Lecture 22

### DIFF
--- a/eatgo-api/src/main/kotlin/kr/co/fastcampus/eatgo/application/RestaurantService.kt
+++ b/eatgo-api/src/main/kotlin/kr/co/fastcampus/eatgo/application/RestaurantService.kt
@@ -2,6 +2,7 @@ package kr.co.fastcampus.eatgo.application
 
 import kr.co.fastcampus.eatgo.domain.MenuItemRepository
 import kr.co.fastcampus.eatgo.domain.Restaurant
+import kr.co.fastcampus.eatgo.domain.RestaurantNotFoundException
 import kr.co.fastcampus.eatgo.domain.RestaurantRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
@@ -22,7 +23,8 @@ class RestaurantService {
     }
 
     fun getRestaurant(id: Long): Restaurant? {
-        val restaurant = restaurantRepository.findById(id).orElse(null)
+        val restaurant = restaurantRepository.findById(id)
+                .orElseThrow { RestaurantNotFoundException(id) }
 
         val menuItems = menuItemRepository.findAllByRestaurantId(id)
 

--- a/eatgo-api/src/main/kotlin/kr/co/fastcampus/eatgo/domain/RestaurantNotFoundException.kt
+++ b/eatgo-api/src/main/kotlin/kr/co/fastcampus/eatgo/domain/RestaurantNotFoundException.kt
@@ -1,0 +1,4 @@
+package kr.co.fastcampus.eatgo.domain
+
+class RestaurantNotFoundException(id: Long) :
+        RuntimeException("Could not find restaurant $id")

--- a/eatgo-api/src/main/kotlin/kr/co/fastcampus/eatgo/interfaces/RestaurantErrorAdvise.kt
+++ b/eatgo-api/src/main/kotlin/kr/co/fastcampus/eatgo/interfaces/RestaurantErrorAdvise.kt
@@ -1,0 +1,16 @@
+package kr.co.fastcampus.eatgo.interfaces
+
+import kr.co.fastcampus.eatgo.domain.RestaurantNotFoundException
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ControllerAdvice
+class RestaurantErrorAdvise {
+    @ResponseBody
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(RestaurantNotFoundException::class)
+    fun handleNotFound() = "{}"
+}

--- a/eatgo-api/src/test/kotlin/kr/co/fastcampus/eatgo/application/RestaurantServiceTest.kt
+++ b/eatgo-api/src/test/kotlin/kr/co/fastcampus/eatgo/application/RestaurantServiceTest.kt
@@ -1,13 +1,11 @@
 package kr.co.fastcampus.eatgo.application
 
 import com.nhaarman.mockitokotlin2.any
-import kr.co.fastcampus.eatgo.domain.MenuItem
-import kr.co.fastcampus.eatgo.domain.MenuItemRepository
-import kr.co.fastcampus.eatgo.domain.Restaurant
-import kr.co.fastcampus.eatgo.domain.RestaurantRepository
+import kr.co.fastcampus.eatgo.domain.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.BDDMockito.given
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
@@ -65,7 +63,7 @@ internal class RestaurantServiceTest {
     }
 
     @Test
-    fun getRestaurant() {
+    fun getRestaurantWithExisted() {
         val restaurant = restaurantService.getRestaurant(1004)
 
         print(restaurant)
@@ -74,7 +72,14 @@ internal class RestaurantServiceTest {
         assertThat(restaurant?.menuItems?.get(0)?.name).isEqualTo("Kimchi")
     }
 
-    @Test
+    @Test()
+    fun getRestaurantWithNotExisted() {
+        assertThrows<RestaurantNotFoundException> {
+            restaurantService.getRestaurant(404)
+        }
+    }
+
+    @Test()
     fun addRestaurant() {
         val restaurant = Restaurant.Builder()
                 .name("BeRyong")

--- a/eatgo-api/src/test/kotlin/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.kt
+++ b/eatgo-api/src/test/kotlin/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import kr.co.fastcampus.eatgo.application.RestaurantService
 import kr.co.fastcampus.eatgo.domain.MenuItem
 import kr.co.fastcampus.eatgo.domain.Restaurant
+import kr.co.fastcampus.eatgo.domain.RestaurantNotFoundException
 import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -52,7 +53,7 @@ internal class RestaurantControllerTest {
     }
 
     @Test
-    fun detail() {
+    fun detailWithExisted() {
         val restaurant1 = Restaurant.Builder()
                 .id(1004)
                 .name("JOKER House")
@@ -93,6 +94,16 @@ internal class RestaurantControllerTest {
                 .andExpect(content().string(
                         containsString("\"name\":\"Cyber food\"")
                 ))
+    }
+
+    @Test
+    fun detailWithNotExisted() {
+        given(restaurantService.getRestaurant(404))
+                .willThrow(RestaurantNotFoundException(404))
+
+        mvc.perform(get("/restaurants/404"))
+                .andExpect(status().isNotFound)
+                .andExpect(content().string("{}"))
     }
 
     @Test


### PR DESCRIPTION
22강 에러 핸들링에 대한 코드 입니다.
`RestaurantNotFoundException`를 처리하기 위해 `RestaurantErrorAdvise`클래스를 추가했습니다.
`RestaurantNotFoundException`가 발생했을 때 응답코드를 `404`, 응답을 `{}`을 반환하도록 추가했습니다.
